### PR TITLE
기술 블로그 목록에 스캐터랩 핑퐁팀 블로그 추가

### DIFF
--- a/blogs/tech_blogs.md
+++ b/blogs/tech_blogs.md
@@ -17,6 +17,7 @@
 * [마이크로소프트](https://techcommunity.microsoft.com/t5/custom/page/page-id/Blogs)
 * [뱅크샐러드](https://blog.banksalad.com/)
 * [비트윈 VCNC](http://engineering.vcnc.co.kr/)
+* [스캐터랩 핑퐁팀](https://blog.pingpong.us/)
 * [스포카](https://spoqa.github.io/)
 * [아마존](https://developer.amazon.com/blogs)
 * [애플](https://developer.apple.com/)


### PR DESCRIPTION
기술 블로그 목록에 스캐터랩 핑퐁팀 블로그를 추가했습니다.

핑퐁은 스캐터랩이 개발하고 있는 일상 대화 챗봇입니다. 주로 Python과 ML 논문 분석 관련 글을 포스팅합니다.